### PR TITLE
Rm typo: `GRCh38_GFP_tdTomato`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ To begin using the Snap pipeline, follow the instructions below to set up the en
 
 ### Tutorial and Documentation
 
-For best practices and detailed guidelines on effectively using the Snap pipeline, please review the [Tutorial and documentation for the snap pipeline](https://github.com/stjude-dnb-binfcore/trainings/blob/main/courses/sc-rna-seq-snap-repo/tutorial/snap-tutorial-docs).
+For a step-by-step guide on how to access the code, run the analysis, and request memory from the HPCF cluster, refer to the current README file or the [Snap wiki page](https://github.com/stjude-dnb-binfcore/sc-rna-seq-snap/wiki). Training sessions can also be provided upon request for St Jude users.
+
+> [Tutorial and documentation for the snap pipeline](https://github.com/stjude-dnb-binfcore/trainings/blob/main/courses/sc-rna-seq-snap-repo/tutorial/snap-tutorial-docs). (legacy): This material reflects a previous version of the Snap pipeline and is no longer actively maintained or supported. It is retained for reference purposes only.
+
+
 
 ### Preparing project metadata
 

--- a/analyses/cell-contamination-removal-analysis/04-find-markers.Rmd
+++ b/analyses/cell-contamination-removal-analysis/04-find-markers.Rmd
@@ -216,14 +216,6 @@ if (genome_name %in% c("GRCh38", "hg19", "GRCh38ANDGRCm39", "GRCh38_mm10", "GRCh
     mutate(species = "human",  # Initialize 'species' as 'human'
            species = case_when(grepl("GRCm39|mm10|mm9", gene) ~ "mouse",  # If 'gene' contains "GRCm39", set 'species' to "mouse"
                                TRUE ~ species))  # Else, keep the value as 'human'
-  
-  } else if (genome_name == "GRCh38_GFP_tdTomato") {  # Check if genome_name is exactly "GRCh38_GFP_tdTomato"
-    
-    all.markers <- all.markers %>%
-        # Grepl the non-human cells
-        mutate(species = "human",  # Initialize 'species' as 'human'
-               species = case_when(grepl("GFP|tdTomato", gene) ~ "tomato",   # If 'gene' contains "GFP", set 'species' to "tomato"
-                               TRUE ~ species))  # Else, keep the value as 'human'
     
     } else if (genome_name %in% c("GRCm39", "mm10", "mm9")) {  # Check if genome_name is "GRCm39", "mm10", and "mm9"
       all.markers <- all.markers %>%

--- a/analyses/clone-phylogeny-analysis/02-prepare-files-for-pileup-and-phase.sh
+++ b/analyses/clone-phylogeny-analysis/02-prepare-files-for-pileup-and-phase.sh
@@ -103,7 +103,7 @@ if [ "$genome_name" = "GRCh38" ]; then
     ########################################################################
 
 else
-    # The pipeline cannot be used yet for for mouse and dual index genomes, i.e., GRCm39, GRCh38ANDGRCm39, and GRCh38_GFP_tdTomato.
+    # The pipeline cannot be used yet for for mouse and dual index genomes.
     echo "Dataset is GRCm39, i.e., mouse genome. The pipeline is currently available for human species only."
     exit 1  # This will stop the script execution if the genome is GRCm39.
 fi

--- a/analyses/cluster-cell-calling/02-find-markers.Rmd
+++ b/analyses/cluster-cell-calling/02-find-markers.Rmd
@@ -217,14 +217,6 @@ if (genome_name %in% c("GRCh38", "hg19", "GRCh38ANDGRCm39", "GRCh38_mm10", "GRCh
     mutate(species = "human",  # Initialize 'species' as 'human'
            species = case_when(grepl("GRCm39|mm10|mm9", gene) ~ "mouse",  # If 'gene' contains "GRCm39", set 'species' to "mouse"
                                TRUE ~ species))  # Else, keep the value as 'human'
-  
-  } else if (genome_name == "GRCh38_GFP_tdTomato") {  # Check if genome_name is exactly "GRCh38_GFP_tdTomato"
-    
-    all.markers <- all.markers %>%
-        # Grepl the non-human cells
-        mutate(species = "human",  # Initialize 'species' as 'human'
-               species = case_when(grepl("GFP|tdTomato", gene) ~ "tomato",   # If 'gene' contains "GFP", set 'species' to "tomato"
-                               TRUE ~ species))  # Else, keep the value as 'human'
     
     } else if (genome_name %in% c("GRCm39", "mm10", "mm9")) {  # Check if genome_name is "GRCm39", "mm10", and "mm9"
       all.markers <- all.markers %>%

--- a/project_parameters.Config.yaml
+++ b/project_parameters.Config.yaml
@@ -3,7 +3,7 @@ root_dir: "/sc-rna-seq-snap" # Absolute path to the main dir of the project wher
 data_dir: "/sc-rna-seq-snap/analyses/cellranger-analysis/results/02_cellranger_count/DefaultParameters" # Absolute path to data dir of the project with CellRanger output results. Options: "DefaultParameters", "ForcedCells8000Parameters", or else. 
 metadata_dir: "/sc-rna-seq-snap/data/project_metadata" # Absolute path to metadata dir of the project. File name always named as: `project_metadata.tsv`.
 metadata_file: "project_metadata.tsv" # Options: "project_metadata.tsv" (default) or name as user wants. It needs to be in `tsv` format. It can include one or more samples, as long as it contains at least the following columns in this exact order: `ID`, `SAMPLE`, and `FASTQ`. The `ID` column must contain unique values. Additional metadata columns can be added and arranged as needed by the user (though not required). For samples with multiple technical replicates, list all associated FASTQ file paths in the same row, using commas to separate each path.
-genome_name: "GRCm39" # define genome reference and versioning. Options: (1) human: "GRCh38", "hg19", and "GRCh38_GFP_tdTomato"; (2) mouse: "GRCm39", "mm10", and "mm9"; and (3) dual index genomes: "GRCh38ANDGRCm39", "GRCh38_mm10", and "GRCh38_mm9".
+genome_name: "GRCm39" # define genome reference and versioning. Options: (1) human: "GRCh38" and "hg19"; (2) mouse: "GRCm39", "mm10", and "mm9"; and (3) dual index genomes: "GRCh38ANDGRCm39", "GRCh38_mm10", and "GRCh38_mm9".
 PROJECT_NAME: "PROJECT_NAME"
 PI_NAME: "PI_NAME"
 TASK_ID: "NA"


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

<!-- Check all those that apply or remove this section if it is not applicable.-->

# Purpose/implementation Section

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## What scientific question/module of analysis is your analysis addressing?

The bug reported [here](https://github.com/stjude-dnb-binfcore/sc-rna-seq-snap/issues/241) was caused by a stale genome identifier (GRCh38_GFP_tdTomato) that remained in the YAML configuration, documentation, and wiki, even though the genome is no longer maintained under that code name. Because it remained:

- The interface suggested it was a valid selection.
- The upstream module did not implement support.
- Selecting it caused the Seurat processing step to return NULL.
- Downstream code failed due to attempting to operate on NULL objects.

All genome names and their codes for the YAML file are also in the [wiki page](https://github.com/stjude-dnb-binfcore/sc-rna-seq-snap/wiki/2.-Genome-References).

### 🔧 Resolution (Correct Approach)

Remove GRCh38_GFP_tdTomato and all other outdated genome names from:

- YAML options
- Documentation
- Wiki pages
- Any README or report templates
- Any conditional checks in R scripts
- Any metadata schemas


## What GitHub issue does your pull request address?

Closes #241.


## Directions for reviewers 
Tell potential reviewers what kind of feedback you are soliciting.

### Which areas should receive a particularly close look?

Please review all files in the snap pipeline and report if/where there is another outdated reference to the Tomato genome reference other in the YAML.


