### PR TITLE
Fix bug with colors in the integration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <img src="https://www.repostatus.org/badges/latest/active.svg?style=for-the-badge" alt="The project has reached a stable, usable state and is being actively developed." />
   </a>
   <a href="https://github.com/stjude-dnb-binfcore/sc-rna-seq-snap">
-    <img src="https://img.shields.io/badge/version-1.0.0.beta.7-brightgreen" alt="Version" />
+    <img src="https://img.shields.io/badge/version-1.0.0.beta.8-brightgreen" alt="Version" />
   </a>
 </p>
 

--- a/analyses/cell-contamination-removal-analysis/02-integrative-analysis.Rmd
+++ b/analyses/cell-contamination-removal-analysis/02-integrative-analysis.Rmd
@@ -253,7 +253,7 @@ if (use_seurat_integration == "YES"){
   
   # Make seurat_list
   seurat_obj_list <- list()
-  seurat_obj_list <- SplitObject(merged_obj, split.by = "orig.ident")
+  seurat_obj_list <- SplitObject(merged_obj, split.by = variable_value)
 
   # Run function
   seurat_obj <- seurat_integration(seurat_obj_list = seurat_obj_list, 
@@ -284,8 +284,8 @@ if (use_harmony_integration == "YES"){
                                     num_dim = num_dim_harmony)
   # Plot
   name <- paste0(plots_dir, "/", glue::glue("plot_{integration_method}.png"))
-  p1 <- DimPlot(object = seurat_obj, reduction = glue::glue("{integration_method}"), pt.size = .1, group.by = "orig.ident") + NoLegend()
-  p2 <- VlnPlot(object = seurat_obj, features = "harmony_1", group.by = "orig.ident", pt.size = .1) + NoLegend()
+  p1 <- DimPlot(object = seurat_obj, reduction = glue::glue("{integration_method}"), pt.size = .1, group.by = variable_value) + NoLegend()
+  p2 <- VlnPlot(object = seurat_obj, features = "harmony_1", group.by = variable_value, pt.size = .1) + NoLegend()
   print(patchwork::wrap_plots(list(p1, p2), nrow = 1))
   ggsave(file = name, width = 12, height = 5, device = "png")
 
@@ -315,7 +315,7 @@ if (use_liger_integration == "YES"){
   
   # Plot
   name <- paste0(plots_dir, "/", glue::glue("plot_{integration_method}.png"))
-  DimPlot(seurat_obj, reduction = glue::glue("{integration_method}"), group.by = c("orig.ident")) + ggtitle(glue::glue("Plot {integration_method}"))
+  DimPlot(seurat_obj, reduction = glue::glue("{integration_method}"), group.by = c(variable_value)) + ggtitle(glue::glue("Plot {integration_method}"))
   ggsave(file = name, width = 6, height = 5, device = "png")
   
   } else {
@@ -329,8 +329,8 @@ Here, `r print_message`.
 ```{r plot-unitegrated-vs-integrated, fig.width = 12, fig.height = 5, fig.fullwidth = TRUE, echo = TRUE}
 # Plot
 name <- paste0(plots_dir, "/", glue::glue("plot_unitegrated_vs_{integration_method}.png"))
-p1 <- DimPlot(merged_obj, group.by = c("orig.ident")) + ggtitle("Before integration")
-p2 <- DimPlot(seurat_obj, reduction = "umap", group.by = c("orig.ident")) + ggtitle(glue::glue("After {integration_method} integration"))  
+p1 <- DimPlot(merged_obj, group.by = c(variable_value)) + ggtitle("Before integration")
+p2 <- DimPlot(seurat_obj, reduction = "umap", group.by = c(variable_value)) + ggtitle(glue::glue("After {integration_method} integration"))  
 patchwork::wrap_plots(list(p1, p2), nrow = 1) 
 ggsave(file = name, width = 12, height = 5, device = "png")
 ```
@@ -345,9 +345,15 @@ ggsave(file = name, width = 6, height = 5, device = "png")
 ```
 
 ```{r plot-fraction-of-cells, fig.width = 10, fig.height = 5, fig.fullwidth = TRUE, echo = TRUE}
+# Build the plot to access scales
+pb <- ggplot_build(p1)
+
+# Extract colors used for the groups
+colors_p1 <- pb$plot$scales$get_scales("colour")$palette.cache
+
 # Plot
 name <- paste0(plots_dir, "/", glue::glue("plot_fraction_of_cells_{integration_method}.png"))
-plot_integrated_clusters(seurat_obj)
+plot_integrated_clusters(seurat_obj, palette = colors_p1, variable_value = variable_value)
 ggsave(file = name, width = 10, height = 6, device = "png")
 ```
 

--- a/analyses/integrative-analysis/01-integrative-analysis.Rmd
+++ b/analyses/integrative-analysis/01-integrative-analysis.Rmd
@@ -350,7 +350,7 @@ colors_p1 <- pb$plot$scales$get_scales("colour")$palette.cache
 
 # Plot
 name <- paste0(plots_dir, "/", glue::glue("plot_fraction_of_cells_{integration_method}.png"))
-plot_integrated_clusters(seurat_obj, palette = colors_p1, variable_value = variable_value)
+plot_integrated_clusters(seurat_obj, palette = colors_p1)
 ggsave(file = name, width = 10, height = 6, device = "png")
 ```
 

--- a/analyses/integrative-analysis/01-integrative-analysis.Rmd
+++ b/analyses/integrative-analysis/01-integrative-analysis.Rmd
@@ -342,9 +342,15 @@ ggsave(file = name, width = 6, height = 5, device = "png")
 ```
 
 ```{r plot-fraction-of-cells, fig.width = 10, fig.height = 5, fig.fullwidth = TRUE, echo = TRUE}
+# Build the plot to access scales
+pb <- ggplot_build(p1)
+
+# Extract colors used for the groups
+colors_p1 <- pb$plot$scales$get_scales("colour")$palette.cache
+
 # Plot
 name <- paste0(plots_dir, "/", glue::glue("plot_fraction_of_cells_{integration_method}.png"))
-plot_integrated_clusters(seurat_obj)
+plot_integrated_clusters(seurat_obj, palette = colors_p1)
 ggsave(file = name, width = 10, height = 6, device = "png")
 ```
 

--- a/analyses/integrative-analysis/01-integrative-analysis.Rmd
+++ b/analyses/integrative-analysis/01-integrative-analysis.Rmd
@@ -250,7 +250,7 @@ if (use_seurat_integration == "YES"){
   
   # Make seurat_list
   seurat_obj_list <- list()
-  seurat_obj_list <- SplitObject(merged_obj, split.by = "orig.ident")
+  seurat_obj_list <- SplitObject(merged_obj, split.by = variable_value)
 
   # Run function
   seurat_obj <- seurat_integration(seurat_obj_list = seurat_obj_list, 
@@ -281,8 +281,8 @@ if (use_harmony_integration == "YES"){
                                     num_dim = num_dim_harmony)
   # Plot
   name <- paste0(plots_dir, "/", glue::glue("plot_{integration_method}.png"))
-  p1 <- DimPlot(object = seurat_obj, reduction = glue::glue("{integration_method}"), pt.size = .1, group.by = "orig.ident") + NoLegend()
-  p2 <- VlnPlot(object = seurat_obj, features = "harmony_1", group.by = "orig.ident", pt.size = .1) + NoLegend()
+  p1 <- DimPlot(object = seurat_obj, reduction = glue::glue("{integration_method}"), pt.size = .1, group.by = variable_value) + NoLegend()
+  p2 <- VlnPlot(object = seurat_obj, features = "harmony_1", group.by = variable_value, pt.size = .1) + NoLegend()
   print(patchwork::wrap_plots(list(p1, p2), nrow = 1))
   ggsave(file = name, width = 12, height = 5, device = "png")
 
@@ -312,7 +312,7 @@ if (use_liger_integration == "YES"){
   
   # Plot
   name <- paste0(plots_dir, "/", glue::glue("plot_{integration_method}.png"))
-  DimPlot(seurat_obj, reduction = glue::glue("{integration_method}"), group.by = c("orig.ident")) + ggtitle(glue::glue("Plot {integration_method}"))
+  DimPlot(seurat_obj, reduction = glue::glue("{integration_method}"), group.by = c(variable_value)) + ggtitle(glue::glue("Plot {integration_method}"))
   ggsave(file = name, width = 6, height = 5, device = "png")
   
   } else {
@@ -326,8 +326,8 @@ Here, `r print_message`.
 ```{r plot-unitegrated-vs-integrated, fig.width = 12, fig.height = 5, fig.fullwidth = TRUE, echo = TRUE}
 # Plot
 name <- paste0(plots_dir, "/", glue::glue("plot_unitegrated_vs_{integration_method}.png"))
-p1 <- DimPlot(merged_obj, group.by = c("orig.ident")) + ggtitle("Before integration")
-p2 <- DimPlot(seurat_obj, reduction = "umap", group.by = c("orig.ident")) + ggtitle(glue::glue("After {integration_method} integration"))  
+p1 <- DimPlot(merged_obj, group.by = c(variable_value)) + ggtitle("Before integration")
+p2 <- DimPlot(seurat_obj, reduction = "umap", group.by = c(variable_value)) + ggtitle(glue::glue("After {integration_method} integration"))  
 patchwork::wrap_plots(list(p1, p2), nrow = 1) 
 ggsave(file = name, width = 12, height = 5, device = "png")
 ```
@@ -350,7 +350,7 @@ colors_p1 <- pb$plot$scales$get_scales("colour")$palette.cache
 
 # Plot
 name <- paste0(plots_dir, "/", glue::glue("plot_fraction_of_cells_{integration_method}.png"))
-plot_integrated_clusters(seurat_obj, palette = colors_p1)
+plot_integrated_clusters(seurat_obj, palette = colors_p1, variable_value = variable_value)
 ggsave(file = name, width = 10, height = 6, device = "png")
 ```
 

--- a/analyses/integrative-analysis/01-integrative-analysis.Rmd
+++ b/analyses/integrative-analysis/01-integrative-analysis.Rmd
@@ -350,7 +350,7 @@ colors_p1 <- pb$plot$scales$get_scales("colour")$palette.cache
 
 # Plot
 name <- paste0(plots_dir, "/", glue::glue("plot_fraction_of_cells_{integration_method}.png"))
-plot_integrated_clusters(seurat_obj, palette = colors_p1)
+plot_integrated_clusters(seurat_obj, palette = colors_p1, variable_value = variable_value)
 ggsave(file = name, width = 10, height = 6, device = "png")
 ```
 

--- a/analyses/integrative-analysis/util/custom-seurat-functions.R
+++ b/analyses/integrative-analysis/util/custom-seurat-functions.R
@@ -29,7 +29,8 @@ plot_integrated_clusters = function (seurat_obj) {
     theme_bw() + scale_x_log10() + xlab("Cells per cluster, log10 scale") + ylab("")
   p2 <- ggplot(melt_mtx,aes(x=cluster,y=value,fill=dataset)) + 
     geom_bar(position="fill", stat="identity") + theme_bw() + coord_flip() + 
-    scale_fill_brewer(palette = "Set2") +
+    #scale_fill_brewer(palette = "Set2") +
+    scale_fill_viridis_d() +
     ylab("Fraction of cells in each dataset") + xlab("Cluster number") + theme(legend.position="top")
   
   p2 + p1 + plot_layout(widths = c(3,1))

--- a/analyses/integrative-analysis/util/custom-seurat-functions.R
+++ b/analyses/integrative-analysis/util/custom-seurat-functions.R
@@ -1,13 +1,14 @@
 ############################################################################################################
 #' Function to plot fraction of cells per sample and cluster
 #' @param seurat_obj
+#' @param palette description
 #'
 #' @return
 #' @export
 #'
 #' @examples
 #' 
-plot_integrated_clusters = function (seurat_obj) { 
+plot_integrated_clusters = function (seurat_obj, palette) { 
   ## take an integrated Seurat object, plot distributions over orig.ident
   
   count_table <- table(seurat_obj@meta.data$seurat_clusters, seurat_obj@meta.data$orig.ident)
@@ -15,7 +16,7 @@ plot_integrated_clusters = function (seurat_obj) {
   count_mtx$cluster <- rownames(count_mtx)
   melt_mtx    <- melt(count_mtx)
   melt_mtx$cluster <- as.factor(melt_mtx$cluster)
-
+  
   cluster_size   <- aggregate(value ~ cluster, data = melt_mtx, FUN = sum)
   
   sorted_labels <- paste(sort(as.integer(levels(cluster_size$cluster)),decreasing = T))
@@ -25,12 +26,12 @@ plot_integrated_clusters = function (seurat_obj) {
   colnames(melt_mtx)[2] <- "dataset"
   
   
-  p1 <- ggplot(cluster_size, aes(y= cluster,x = value)) + geom_bar(position="dodge", stat="identity",fill = "grey60") + 
+  p1 <- ggplot(cluster_size, aes(y= cluster,x = value)) + geom_bar(position="dodge", stat="identity", fill = "grey60") + 
     theme_bw() + scale_x_log10() + xlab("Cells per cluster, log10 scale") + ylab("")
   p2 <- ggplot(melt_mtx,aes(x=cluster,y=value,fill=dataset)) + 
     geom_bar(position="fill", stat="identity") + theme_bw() + coord_flip() + 
     #scale_fill_brewer(palette = "Set2") +
-    scale_fill_viridis_d() +
+    scale_fill_manual(values = palette) +
     ylab("Fraction of cells in each dataset") + xlab("Cluster number") + theme(legend.position="top")
   
   p2 + p1 + plot_layout(widths = c(3,1))

--- a/analyses/integrative-analysis/util/custom-seurat-functions.R
+++ b/analyses/integrative-analysis/util/custom-seurat-functions.R
@@ -2,17 +2,16 @@
 #' Function to plot fraction of cells per sample and cluster
 #' @param seurat_obj
 #' @param palette description
-#' @param variable_value
 #'
 #' @return
 #' @export
 #'
 #' @examples
 #' 
-plot_integrated_clusters = function (seurat_obj, palette, variable_value) { 
-  ## take an integrated Seurat object, plot distributions over the specified variable
+plot_integrated_clusters = function (seurat_obj, palette) { 
+  ## take an integrated Seurat object, plot distributions over orig.ident
   
-  count_table <- table(seurat_obj@meta.data$seurat_clusters, seurat_obj@meta.data[[variable_value]])
+  count_table <- table(seurat_obj@meta.data$seurat_clusters, seurat_obj@meta.data$orig.ident)
   count_mtx   <- as.data.frame.matrix(count_table)
   count_mtx$cluster <- rownames(count_mtx)
   melt_mtx    <- melt(count_mtx)

--- a/analyses/integrative-analysis/util/custom-seurat-functions.R
+++ b/analyses/integrative-analysis/util/custom-seurat-functions.R
@@ -2,16 +2,17 @@
 #' Function to plot fraction of cells per sample and cluster
 #' @param seurat_obj
 #' @param palette description
+#' @param variable_value
 #'
 #' @return
 #' @export
 #'
 #' @examples
 #' 
-plot_integrated_clusters = function (seurat_obj, palette) { 
-  ## take an integrated Seurat object, plot distributions over orig.ident
+plot_integrated_clusters = function (seurat_obj, palette, variable_value) { 
+  ## take an integrated Seurat object, plot distributions over the specified variable
   
-  count_table <- table(seurat_obj@meta.data$seurat_clusters, seurat_obj@meta.data$orig.ident)
+  count_table <- table(seurat_obj@meta.data$seurat_clusters, seurat_obj@meta.data[[variable_value]])
   count_mtx   <- as.data.frame.matrix(count_table)
   count_mtx$cluster <- rownames(count_mtx)
   melt_mtx    <- melt(count_mtx)

--- a/analyses/integrative-analysis/util/custom-seurat-functions.R
+++ b/analyses/integrative-analysis/util/custom-seurat-functions.R
@@ -12,7 +12,7 @@
 plot_integrated_clusters = function (seurat_obj, palette, variable_value) { 
   ## take an integrated Seurat object, plot distributions over the specified variable
   
-  count_table <- table(seurat_obj@meta.data$seurat_clusters, seurat_obj@meta.data$variable_value)
+  count_table <- table(seurat_obj@meta.data$seurat_clusters, seurat_obj@meta.data[[variable_value]])
   count_mtx   <- as.data.frame.matrix(count_table)
   count_mtx$cluster <- rownames(count_mtx)
   melt_mtx    <- melt(count_mtx)

--- a/analyses/integrative-analysis/util/custom-seurat-functions.R
+++ b/analyses/integrative-analysis/util/custom-seurat-functions.R
@@ -1,17 +1,18 @@
 ############################################################################################################
 #' Function to plot fraction of cells per sample and cluster
 #' @param seurat_obj
-#' @param palette description
+#' @param palette 
+#' @param variable_value
 #'
 #' @return
 #' @export
 #'
 #' @examples
 #' 
-plot_integrated_clusters = function (seurat_obj, palette) { 
-  ## take an integrated Seurat object, plot distributions over orig.ident
+plot_integrated_clusters = function (seurat_obj, palette, variable_value) { 
+  ## take an integrated Seurat object, plot distributions over the specified variable
   
-  count_table <- table(seurat_obj@meta.data$seurat_clusters, seurat_obj@meta.data$orig.ident)
+  count_table <- table(seurat_obj@meta.data$seurat_clusters, seurat_obj@meta.data$variable_value)
   count_mtx   <- as.data.frame.matrix(count_table)
   count_mtx$cluster <- rownames(count_mtx)
   melt_mtx    <- melt(count_mtx)


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

<!-- Check all those that apply or remove this section if it is not applicable.-->

# Purpose/implementation Section

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## What scientific question/module of analysis is your analysis addressing?

The `integrative-analysis` module currently has a limitation when using `scale_fill_brewer(palette = "Set2")`, as the palette supports a fixed number of colors, i,e., 8. 

When the number of samples exceeds the size of the Set2 palette, this introduces a bug where some samples are left without an assigned color due to the palette’s fixed number of available colors.

We will update this step to extract the color mapping from the DimPlot and apply the same colors to the fraction-of-cells plot for visual consistency.

## What GitHub issue does your pull request address?

Closes #246.


## Directions for reviewers 
Tell potential reviewers what kind of feedback you are soliciting.

### Which areas should receive a particularly close look?

Please review the code for logic and clarity, and test with a dataset with more than 8 samples.


## Reproducibility Checklist

- [x] The dependencies required to run the code in this pull request have been added to the project Dockerfile.

## Documentation Checklist


- [x] This analysis module has a `README` and it is up to date.
- [x] The analytical code is documented and contains comments.
